### PR TITLE
Refactoring key generation functions

### DIFF
--- a/include/keygen.h
+++ b/include/keygen.h
@@ -122,4 +122,24 @@ class KeyGen
         void get_bsk2(BSKey_LWE& bsk, const SKey_base_LWE& sk_base, const SKey_boot& sk_boot);
 };
 
+/**
+* Encrypts a polynomial into a vector ciphertext under the NTRU problem.
+* @param[out] ct ciphertext encrypting the input
+* @param[in] m polynomial to encrypt
+* @param[in] l dimension of the vector ciphertext
+* @param[in] B base used in the gadget vector
+* @param[in] sk_boot contains f and f^-1
+**/ 
+void enc_ngs(NGSFFTctxt& ct, const ModQPoly& m, int l, int B, const SKey_boot& sk_boot);
+
+/**
+* Encrypts an integer into a vector ciphertext under the NTRU problem.
+* @param[out] ct ciphertext encrypting the input
+* @param[in] m integer to encrypt (it is treated as a degree-0 polynomial)
+* @param[in] l dimension of the vector ciphertext
+* @param[in] B base used in the gadget vector
+* @param[in] sk_boot contains f and f^-1
+**/ 
+void enc_ngs(NGSFFTctxt& ct, int m, int l, int B, const SKey_boot& sk_boot);
+
 #endif

--- a/include/keygen.h
+++ b/include/keygen.h
@@ -128,7 +128,7 @@ class KeyGen
 * @param[in] m polynomial to encrypt
 * @param[in] l dimension of the vector ciphertext
 * @param[in] B base used in the gadget vector
-* @param[in] sk_boot contains f and f^-1
+* @param[in] sk_boot contains bootstrapping secret key and its inverse
 **/ 
 void enc_ngs(NGSFFTctxt& ct, const ModQPoly& m, int l, int B, const SKey_boot& sk_boot);
 
@@ -138,7 +138,7 @@ void enc_ngs(NGSFFTctxt& ct, const ModQPoly& m, int l, int B, const SKey_boot& s
 * @param[in] m integer to encrypt (it is treated as a degree-0 polynomial)
 * @param[in] l dimension of the vector ciphertext
 * @param[in] B base used in the gadget vector
-* @param[in] sk_boot contains f and f^-1
+* @param[in] sk_boot contains bootstrapping secret key and its inverse
 **/ 
 void enc_ngs(NGSFFTctxt& ct, int m, int l, int B, const SKey_boot& sk_boot);
 

--- a/src/lwehe.cpp
+++ b/src/lwehe.cpp
@@ -477,10 +477,10 @@ void SchemeLWE::xor_gate(Ctxt_LWE& ct_res, const Ctxt_LWE& ct1, const Ctxt_LWE& 
 {
     if (ct_res.a.size() != parLWE.n)
         ct_res.a = vector<int>(parLWE.n);
-    for (size_t i = 0; i < parLWE.n; i++)
-        ct_res.a[i] = parLWE.mod_q_base(2*(ct1.a[i] + ct2.a[i])); // a = 2*(ct1.a + ct2.a)
 
-    ct_res.b = parLWE.mod_q_base(2*(ct1.b + ct2.b)); // b = 2*(ct1.b + ct2.b)
+    ct_res = ct1 + ct2;
+    ct_res = ct_res + ct_res; // ct = 2*(ct1 + ct2)
+
     bootstrap(ct_res);
 }
 
@@ -488,9 +488,7 @@ void SchemeLWE::not_gate(Ctxt_LWE& ct_res, const Ctxt_LWE& ct) const
 {
     if (ct_res.a.size() != parLWE.n)
         ct_res.a = vector<int>(parLWE.n);
-    for (size_t i = 0; i < parLWE.n; i++)
-        ct_res.a[i] = -ct.a[i];
-    ct_res.b = parLWE.delta_base - ct.b;
-    ct_res.b = parLWE.mod_q_base(ct_res.b);
+
+    ct_res = parLWE.delta_base - ct;
 }
 

--- a/src/ntruhe.cpp
+++ b/src/ntruhe.cpp
@@ -288,10 +288,9 @@ void SchemeNTRU::xor_gate(Ctxt_NTRU& ct_res, const Ctxt_NTRU& ct1, const Ctxt_NT
 {
     if (ct_res.data.size() != parNTRU.n)
         ct_res.data = vector<int>(parNTRU.n);
-    for (size_t i = 0; i < parNTRU.n; i++){
-        ct_res.data[i] = 2*(ct1.data[i] + ct2.data[i]);
-        ct_res.data[i] = parNTRU.mod_q_base(ct_res.data[i]); // res = 2*(ct1 + ct2) % q
-    }
+
+    ct_res = ct1 + ct2;
+    ct_res = ct_res + ct_res; // ct_res = 2*(ct1 + ct2) % q
 
     bootstrap(ct_res);
 }


### PR DESCRIPTION
 Implemented function to encrypt polynomials into vector ciphertext.

Several parts of the key generation were actually encrypting polynomials
and integers into vector ciphertexts, thus, now they just call the new
function enc_ngs. As a result, the key generation code is simpler to
understand. Moreover, future applications may want to generate vector
ciphertexts, thus, the function enc_ngs is interesting on its own.